### PR TITLE
Add row block

### DIFF
--- a/src/extensions/data_tools/index.js
+++ b/src/extensions/data_tools/index.js
@@ -59,6 +59,21 @@ class DataTools {
                     }
                 },
                 {
+                    opcode: 'addRow',
+                    text: formatMessage({
+                        id: 'datatools.addRow',
+                        default: 'add row to [FILENAME]',
+                        description: 'add an empty row to a file'
+                    }),
+                    blocktype: BlockType.COMMAND,
+                    arguments: {
+                        FILENAME: {
+                            type: ArgumentType.STRING,
+                            menu: 'fileMenu',
+                        }
+                    }
+                },
+                {
                     opcode: 'getColumnAtRow',
                     text: formatMessage({
                         id: 'datatools.getColumnAtRow',

--- a/src/extensions/data_tools/index.js
+++ b/src/extensions/data_tools/index.js
@@ -59,9 +59,9 @@ class DataTools {
                     }
                 },
                 {
-                    opcode: 'addRow',
+                    opcode: 'addDataFileRow',
                     text: formatMessage({
-                        id: 'datatools.addRow',
+                        id: 'datatools.addDataFileRow',
                         default: 'add row to [FILENAME]',
                         description: 'add an empty row to a file'
                     }),
@@ -221,7 +221,7 @@ class DataTools {
         let fileName = colArr[0].substring(1);
         let col = colArr.slice(1, colArr.length).join(']').substring(1);
 
-        if(!files[fileName] || ROW < 1 || ROW > files[fileName].length || !files[fileName][ROW - 1][col]) {
+        if(!files[fileName] || ROW < 1 || ROW > files[fileName].length || files[fileName][ROW - 1][col] === 'undefined') {
             return "";
         }
 
@@ -255,7 +255,7 @@ class DataTools {
         let fileName = colArr[0].substring(1);
         let col = colArr.slice(1, colArr.length).join(']').substring(1);
 
-        if(!files[fileName] || ROW < 1 || ROW > files[fileName].length || !files[fileName][ROW - 1][col]) {
+        if(!files[fileName] || ROW < 1 || ROW > files[fileName].length || files[fileName][ROW - 1][col]  === 'undefined') {
             return "";
         }
         console.log(files[fileName][ROW - 1][col]); 
@@ -272,6 +272,9 @@ class DataTools {
 
     addDataFileRow(args) {
         let { FILENAME } = args;
+        if(!FILENAME || FILENAME === ''){
+            return;
+        }
 
         let first = files[FILENAME][0];
         let newRow = {};


### PR DESCRIPTION
### Resolves

https://trello.com/c/s28T2Mxj/29-2-add-row-functionality

### Proposed Changes

Added add row button, using shared opcode from the file visualization module. Modified it to handle the case where there is no file selected, also fixed the error checking on the getColumnAtRow and setColumnAtRow to properly catch error, removing false positives.